### PR TITLE
Implement package build and deploy scripts on AppVeyor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "onnx"]
 	path = onnx
-	url = git://github.com/onnx/onnx.git
+	url = https://github.com/onnx/onnx

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "onnx"]
+	path = onnx
+	url = git://github.com/onnx/onnx.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,25 @@ environment:
   matrix:
   # onnx
   - ONNX_ML: 0
+    ONNXPY_DIR: C:\Python36
+    CONDA_PREFIX: C:\Miniconda36
+
+  - ONNX_ML: 0
     ONNXPY_DIR: C:\Python36-x64
     CONDA_PREFIX: C:\Miniconda36-x64
+
+  - ONNX_ML: 0
+    ONNXPY_DIR: C:\Python35
+    CONDA_PREFIX: C:\Miniconda35
+
+  - ONNX_ML: 0
+    ONNXPY_DIR: C:\Python35-x64
+    CONDA_PREFIX: C:\Miniconda35-x64
+
+  # onnx-ml
+  - ONNX_ML: 1
+    ONNXPY_DIR: C:\Python36
+    CONDA_PREFIX: C:\Miniconda36
 
 install:
 - cmd: git submodule update --init --recursive
@@ -47,8 +64,9 @@ artifacts:
 after_test:
 - cmd: set REPO=https://test.pypi.org/legacy/
 - cmd: set USERNAME=raymondxyang
+# Ensure only master branch can trigger build
 - >
-  IF "%APPVEYOR_REPO_BRANCH%" == "ziya-wheelbuild"
+  IF "%APPVEYOR_REPO_BRANCH%" == "master"
   (
   python -m pip install twine &&
   set HOME=%USERPROFILE% &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,63 @@
+# reference: https://www.appveyor.com/docs/appveyor-yml/
+
+version: 0.3.{build}
+
+# build all branches by default
+
+image: Visual Studio 2017
+platform: x64
+configuration: Release
+
+clone_folder: c:\projects\wheel-builder
+clone_depth: 10
+
+# pick as per https://www.appveyor.com/docs/build-environment/#python
+environment:
+  PYPI_PASSWORD:
+    secure: 88m5KgPwi+WCPy5wJlxvRA==
+
+  matrix:
+  # onnx
+  - ONNX_ML: 0
+    ONNXPY_DIR: C:\Python36
+    CONDA_PREFIX: C:\Miniconda36
+
+
+install:
+- cmd: git submodule update --init --recursive
+
+before_build:
+- cmd: SET PATH=%CONDA_PREFIX%;%CONDA_PREFIX%\Scripts;%PATH%
+- cmd: conda install -y -c conda-forge protobuf numpy
+- cmd: pip install pytest-cov nbval
+
+build_script:
+# Build and test onnx.
+- cmd: cd c:\projects\wheel-builder\onnx
+- cmd: python setup.py bdist_wheel --universal --dist-dir .
+- cmd: pip uninstall -y onnx
+- cmd: dir /b /a-d "*.whl" >WheelFile.txt & set /p _wheel= < WheelFile.txt
+- cmd: pip install %_wheel%
+- cmd: pytest
+
+artifacts:
+  - path: 'onnx\*.whl'
+    name: ONNXWheel
+
+# publish artifacts
+after_test:
+- >
+  IF "%APPVEYOR_REPO_BRANCH%" == "master"
+  (
+  echo [distutils]                                  > %USERPROFILE%\\.pypirc &&
+  echo index-servers =                             >> %USERPROFILE%\\.pypirc &&
+  echo     testpypi                                >> %USERPROFILE%\\.pypirc &&
+  echo [testpypi]                                  >> %USERPROFILE%\\.pypirc &&
+  echo repository: https://test.pypi.org/legacy/   >> %USERPROFILE%\\.pypirc &&
+  echo username: raymondxyang                      >> %USERPROFILE%\\.pypirc &&
+  echo password: %PYPI_PASSWORD%                   >> %USERPROFILE%\\.pypirc &&
+  python -m pip install twine &&
+  set HOME=%USERPROFILE% &&
+  python -m twine upload %_wheel% &&
+  del /f %USERPROFILE%\\.pypirc
+  )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,26 +21,21 @@ environment:
 
   matrix:
   # onnx
-  - ONNX_ML: 0
-    ONNXPY_DIR: C:\Python36
-    CONDA_PREFIX: C:\Miniconda36
-
-  - ONNX_ML: 0
-    ONNXPY_DIR: C:\Python36-x64
-    CONDA_PREFIX: C:\Miniconda36-x64
-
-  - ONNX_ML: 0
-    ONNXPY_DIR: C:\Python35
-    CONDA_PREFIX: C:\Miniconda35
-
-  - ONNX_ML: 0
-    ONNXPY_DIR: C:\Python35-x64
-    CONDA_PREFIX: C:\Miniconda35-x64
-
-  # onnx-ml
   - ONNX_ML: 1
     ONNXPY_DIR: C:\Python36
     CONDA_PREFIX: C:\Miniconda36
+
+  - ONNX_ML: 1
+    ONNXPY_DIR: C:\Python36-x64
+    CONDA_PREFIX: C:\Miniconda36-x64
+
+  - ONNX_ML: 1
+    ONNXPY_DIR: C:\Python35
+    CONDA_PREFIX: C:\Miniconda35
+
+  - ONNX_ML: 1
+    ONNXPY_DIR: C:\Python35-x64
+    CONDA_PREFIX: C:\Miniconda35-x64
 
 install:
 - cmd: git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,10 @@ clone_depth: 10
 # pick as per https://www.appveyor.com/docs/build-environment/#python
 environment:
   PYPI_PASSWORD:
-    secure: 88m5KgPwi+WCPy5wJlxvRA==
+    secure: yARz+ghryFiIZJSwJqFL3BUzWecf8cR54+aKTJApNIM=
+  
+  PYPI_USERNAME:
+    secure: Qb6DerVCR79/zeJZrCl1wA==
 
   matrix:
   # onnx
@@ -63,7 +66,7 @@ artifacts:
 # publish artifacts
 after_test:
 - cmd: set REPO=https://test.pypi.org/legacy/
-- cmd: set USERNAME=raymondxyang
+- cmd: set USERNAME=%PYPI_USERNAME%
 # Ensure only master branch can trigger build
 - >
   IF "%APPVEYOR_REPO_BRANCH%" == "master"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,8 @@ environment:
   matrix:
   # onnx
   - ONNX_ML: 0
-    ONNXPY_DIR: C:\Python36
-    CONDA_PREFIX: C:\Miniconda36
-
+    ONNXPY_DIR: C:\Python36-x64
+    CONDA_PREFIX: C:\Miniconda36-x64
 
 install:
 - cmd: git submodule update --init --recursive
@@ -35,7 +34,7 @@ build_script:
 # Build and test onnx.
 - cmd: cd c:\projects\wheel-builder\onnx
 - cmd: python setup.py bdist_wheel --universal --dist-dir .
-- cmd: pip uninstall -y onnx
+- cmd: pip uninstall -y onnx || ver>nul
 - cmd: dir /b /a-d "*.whl" >WheelFile.txt & set /p _wheel= < WheelFile.txt
 - cmd: pip install %_wheel%
 - cmd: pytest
@@ -46,18 +45,13 @@ artifacts:
 
 # publish artifacts
 after_test:
+- cmd: set REPO=https://test.pypi.org/legacy/
+- cmd: set USERNAME=raymondxyang
 - >
-  IF "%APPVEYOR_REPO_BRANCH%" == "master"
+  IF "%APPVEYOR_REPO_BRANCH%" == "ziya-wheelbuild"
   (
-  echo [distutils]                                  > %USERPROFILE%\\.pypirc &&
-  echo index-servers =                             >> %USERPROFILE%\\.pypirc &&
-  echo     testpypi                                >> %USERPROFILE%\\.pypirc &&
-  echo [testpypi]                                  >> %USERPROFILE%\\.pypirc &&
-  echo repository: https://test.pypi.org/legacy/   >> %USERPROFILE%\\.pypirc &&
-  echo username: raymondxyang                      >> %USERPROFILE%\\.pypirc &&
-  echo password: %PYPI_PASSWORD%                   >> %USERPROFILE%\\.pypirc &&
   python -m pip install twine &&
   set HOME=%USERPROFILE% &&
-  python -m twine upload %_wheel% &&
-  del /f %USERPROFILE%\\.pypirc
+  python -m twine upload --skip-existing %_wheel% --repository-url %REPO% -u %USERNAME% -p %PYPI_PASSWORD%
   )
+- cmd: del /f %USERPROFILE%\\.pypirc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,10 +69,13 @@ after_test:
 - cmd: set USERNAME=%PYPI_USERNAME%
 # Ensure only master branch can trigger build
 - >
-  IF "%APPVEYOR_REPO_BRANCH%" == "master"
+  IF "%APPVEYOR_REPO_BRANCH%" == "master" 
+  (
+  IF "%APPVEYOR_REPO_TAG%" == "true"
   (
   python -m pip install twine &&
   set HOME=%USERPROFILE% &&
   python -m twine upload --skip-existing %_wheel% --repository-url %REPO% -u %USERNAME% -p %PYPI_PASSWORD%
+  )
   )
 - cmd: echo TASK COMPLETED

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,4 +75,4 @@ after_test:
   set HOME=%USERPROFILE% &&
   python -m twine upload --skip-existing %_wheel% --repository-url %REPO% -u %USERNAME% -p %PYPI_PASSWORD%
   )
-- cmd: del /f %USERPROFILE%\\.pypirc
+- cmd: echo TASK COMPLETED


### PR DESCRIPTION
## NOTE: Merge this PR will only enable publish package on TestPyPI. Will send a PR when Test is done
- Added bdist wheel build script on AppVeyor
- Implemented deploy script for TestPyPI

### Next:
- Publish to PyPI
- Enable CI policy for wheel builder
- Publish built for other platforms
