### PR TITLE
Bring linux builds back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,11 @@ matrix:
   - os: linux 
     sudo: required 
     env: 
+      - MB_PYTHON_VERSION=3.7 
+      - ONNX_ML=1 
+  - os: linux 
+    sudo: required 
+    env: 
       - MB_PYTHON_VERSION=3.5 
       - ONNX_ML=1 
       - PLAT=i686 
@@ -101,6 +106,12 @@ matrix:
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.6 
+      - ONNX_ML=1 
+      - PLAT=i686
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=3.7 
       - ONNX_ML=1 
       - PLAT=i686
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ dist: xenial
 services: docker
 # Force xcode 6.4 image to work round
 # https://github.com/python-pillow/pillow-wheels/issues/45
-osx_image: xcode9.3beta
+# So we have the line below for OSX builds
+# osx_image: xcode9.3beta
 matrix:
   # Exclude the default Python 3.5 build
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,15 @@ language: python
 # Default Python version is usually 2.7
 python: 3.5
 sudo: required
-dist: trusty
+dist: xenial
 services: docker
 # Force xcode 6.4 image to work round
 # https://github.com/python-pillow/pillow-wheels/issues/45
 osx_image: xcode9.3beta
-
 matrix:
+  # Exclude the default Python 3.5 build
   exclude:
-    # Exclude the default Python 3.5 build
-    - python: 3.5
+  - python: 3.5
   include:
   - os: osx
     language: generic
@@ -33,7 +32,6 @@ matrix:
       - MB_PYTHON_VERSION=3.5
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
-
   - os: osx
     language: generic
     sudo: required
@@ -42,7 +40,6 @@ matrix:
       - MB_PYTHON_VERSION=3.6
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
-  
   - os: osx
     language: generic
     sudo: required
@@ -51,7 +48,6 @@ matrix:
       - MB_PYTHON_VERSION=3.7
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
-  
   - os: osx
     language: generic
     sudo: required
@@ -60,6 +56,52 @@ matrix:
       - MB_PYTHON_VERSION=2.7
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=2.7 
+      - ONNX_ML=1 
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=2.7 
+      - ONNX_ML=1 
+      - UNICODE_WIDTH=16 
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=2.7 
+      - ONNX_ML=1 
+      - PLAT=i686 
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=2.7 
+      - ONNX_ML=1 
+      - UNICODE_WIDTH=16 
+      - PLAT=i686 
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=3.5 
+      - ONNX_ML=1 
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=3.6 
+      - ONNX_ML=1 
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=3.5 
+      - ONNX_ML=1 
+      - PLAT=i686 
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=3.6 
+      - ONNX_ML=1 
+      - PLAT=i686
 
 before_install:
   - source multibuild/common_utils.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ language: python
 # Default Python version is usually 2.7
 python: 3.5
 sudo: required
-dist: xenial
+dist: trusty
 services: docker
 # Force xcode 6.4 image to work round
 # https://github.com/python-pillow/pillow-wheels/issues/45

--- a/config.sh
+++ b/config.sh
@@ -38,8 +38,8 @@ function build_libs {
     if [ -z "$IS_OSX" ]; then
        cmake_dir="${wkdir_path}/cmake"
        mkdir -p "$cmake_dir"
-       curl -L -O https://cmake.org/files/v3.1/cmake-3.1.2.tar.gz
-       tar -xzf cmake-3.1.2.tar.gz -C "$cmake_dir" --strip-components 1
+       curl -L -O https://cmake.org/files/v3.3/cmake-3.3.2.tar.gz
+       tar -xzf cmake-3.3.2.tar.gz -C "$cmake_dir" --strip-components 1
        cd ${cmake_dir} && ls ${cmake_dir}
        ./configure --prefix=${cmake_dir}/build
        make -j${NUMCORES} && make install


### PR DESCRIPTION
As mentioned in https://github.com/onnx/wheel-builder/issues/17, some Linux builds were removed. To generate Linux packages, I'd like to add them back so that we can reuse this infrastructure. Note that the CMake version is updated because, to build ONNX, we need higher CMake version for a newly added Cmake attribute.