### PR TITLE
Upgrade python version to install the right twine

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,6 +85,11 @@ artifacts:
 
 # publish artifacts
 after_test:
+# The package twine needs python >= 3.6, so we
+# need another conda enviroment to install
+# the right twine.
+- cmd: conda create -n -y twine-publish python=3.6
+- cmd: conda activate twine-publish
 - cmd: set REPO=https://upload.pypi.org/legacy/
 - cmd: set TESTREPO=https://test.pypi.org/legacy/
 - cmd: set USERNAME=%PYPI_USERNAME%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ after_test:
 # The package twine needs python >= 3.6, so we
 # need another conda enviroment to install
 # the right twine.
-- cmd: conda create -n -y twine-publish python=3.6
+- cmd: conda create -y -n twine-publish python=3.6
 - cmd: conda activate twine-publish
 - cmd: set REPO=https://upload.pypi.org/legacy/
 - cmd: set TESTREPO=https://test.pypi.org/legacy/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,14 +85,15 @@ artifacts:
 
 # publish artifacts
 after_test:
-# The package twine needs python >= 3.6, so we
-# need another conda enviroment to install
-# the right twine.
-- cmd: conda create -y -n twine-publish python=3.6
-- cmd: conda activate twine-publish
 - cmd: set REPO=https://upload.pypi.org/legacy/
 - cmd: set TESTREPO=https://test.pypi.org/legacy/
 - cmd: set USERNAME=%PYPI_USERNAME%
+# The package twine requires python >= 3.6, so
+# we upgrade python before doing anything related
+# to twine. Note that twine is only for publishing
+# packages, so this change won't affect the package
+# we built.
+- cmd: conda upgrade -y python
 # Ensure only master branch can trigger build
 - >
   IF "%APPVEYOR_REPO_BRANCH%" == "master"
@@ -101,7 +102,7 @@ after_test:
   (
   python -m pip install twine &&
   set HOME=%USERPROFILE% &&
-  python -m twine upload --skip-existing %_wheel% --repository-url %REPO% -u %USERNAME% -p %PYPI_PASSWORD%
+  python -m twine upload --verbose --skip-existing %_wheel% --repository-url %REPO% -u %USERNAME% -p %PYPI_PASSWORD%
   )
   )
 - >
@@ -109,6 +110,6 @@ after_test:
   (
   python -m pip install twine &&
   set HOME=%USERPROFILE% &&
-  python -m twine upload --skip-existing %_wheel% --repository-url %TESTREPO% -u %USERNAME% -p %PYPI_PASSWORD%
+  python -m twine upload --verbose --skip-existing %_wheel% --repository-url %TESTREPO% -u %USERNAME% -p %PYPI_PASSWORD%
   )
 - cmd: echo TASK COMPLETED


### PR DESCRIPTION
Twine dropped its python 3.5 support. If we want to publish a package to pypi, we need to upgrade the python in the selected conda before
1. installing twine
2. publishing the wheel.

Note that for conda with python=3.5, this upgrade will change the python version to 3.7. This upgrade doesn't affect the wheel files because they are produced before this step.

This change is tested [here](https://ci.appveyor.com/project/wschin/wheel-builder/builds/27740979). Although they all errored due to pypi authorization (it cannot publish package under ONNX account), you can still see that the error messages in python 3.5 builds are not syntax errors anymore.