### PR TITLE
Release ONNX 1.8.0 Preparation: TestPypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
     - REPO_DIR=onnx
-    - BUILD_COMMIT=0c070abb0c40fec649f81a73a75b0098662ec486
+    - BUILD_COMMIT=63a586914d51fdfd6d8668e81de043e3d9b0b382
     - PLAT=x86_64
     - PB_VERSION=2.6.1
     - UNICODE_WIDTH=32
@@ -54,38 +54,6 @@ matrix:
       - MB_PYTHON_VERSION=3.8
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
-  - os: osx
-    language: generic
-    sudo: required
-    osx_image: xcode9.3beta
-    env:
-      - MB_PYTHON_VERSION=2.7
-      - ONNX_ML=1
-      - MACOSX_DEPLOYMENT_TARGET=10.9
-  - os: linux 
-    sudo: required 
-    env: 
-      - MB_PYTHON_VERSION=2.7 
-      - ONNX_ML=1 
-  - os: linux 
-    sudo: required 
-    env: 
-      - MB_PYTHON_VERSION=2.7 
-      - ONNX_ML=1 
-      - UNICODE_WIDTH=16 
-  - os: linux 
-    sudo: required 
-    env: 
-      - MB_PYTHON_VERSION=2.7 
-      - ONNX_ML=1 
-      - PLAT=i686 
-  - os: linux 
-    sudo: required 
-    env: 
-      - MB_PYTHON_VERSION=2.7 
-      - ONNX_ML=1 
-      - UNICODE_WIDTH=16 
-      - PLAT=i686 
   - os: linux 
     sudo: required 
     env: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ services: docker
 # osx_image: xcode9.3beta
 matrix:
   include:
-  - os: osx
+  - name: "OSX Python 3.5"
+    os: osx
     language: generic
     sudo: required
     osx_image: xcode9.3beta
@@ -30,7 +31,8 @@ matrix:
       - MB_PYTHON_VERSION=3.5
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
-  - os: osx
+  - name: "OSX Python 3.6"
+    os: osx
     language: generic
     sudo: required
     osx_image: xcode9.3beta
@@ -38,7 +40,8 @@ matrix:
       - MB_PYTHON_VERSION=3.6
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
-  - os: osx
+  - name: "OSX Python 3.7"
+    os: osx
     language: generic
     sudo: required
     osx_image: xcode9.3beta
@@ -46,7 +49,8 @@ matrix:
       - MB_PYTHON_VERSION=3.7
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
-  - os: osx
+  - name: "OSX Python 3.8"
+    os: osx
     language: generic
     sudo: required
     osx_image: xcode9.3beta
@@ -54,52 +58,60 @@ matrix:
       - MB_PYTHON_VERSION=3.8
       - ONNX_ML=1
       - MACOSX_DEPLOYMENT_TARGET=10.9
-  - os: linux 
+  - name: "Linux x64 Python 3.5"
+    os: linux 
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.5
       - MB_ML_VER=2014
       - ONNX_ML=1
-  - os: linux 
+  - name: "Linux x64 Python 3.6"
+    os: linux 
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.6
       - MB_ML_VER=2014
       - ONNX_ML=1
-  - os: linux 
+  - name: "Linux x64 Python 3.7"
+    os: linux 
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.7
       - MB_ML_VER=2014
       - ONNX_ML=1
-  - os: linux
+  - name: "Linux x64 Python 3.8"
+    os: linux
     sudo: required
     env:
       - MB_PYTHON_VERSION=3.8
       - MB_ML_VER=2014
       - ONNX_ML=1
-  - os: linux 
+  - name: "Linux x86 Python 3.5"
+    os: linux 
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.5
       - MB_ML_VER=2014
       - ONNX_ML=1
       - PLAT=i686
-  - os: linux 
+  - name: "Linux x86 Python 3.6"
+    os: linux 
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.6
       - MB_ML_VER=2014
       - ONNX_ML=1
       - PLAT=i686
-  - os: linux 
+  - name: "Linux x86 Python 3.7"
+    os: linux 
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.7
       - MB_ML_VER=2014
       - ONNX_ML=1
       - PLAT=i686
-  - os: linux
+  - name: "Linux x86 Python 3.8"
+    os: linux
     sudo: required
     env:
       - MB_PYTHON_VERSION=3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.5
-      - MB_ML_VER=2014
+      - MB_ML_VER=2010
       - ONNX_ML=1
       - PLAT=i686
   - name: "Linux x86 Python 3.6"
@@ -99,7 +99,7 @@ matrix:
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.6
-      - MB_ML_VER=2014
+      - MB_ML_VER=2010
       - ONNX_ML=1
       - PLAT=i686
   - name: "Linux x86 Python 3.7"
@@ -107,7 +107,7 @@ matrix:
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.7
-      - MB_ML_VER=2014
+      - MB_ML_VER=2010
       - ONNX_ML=1
       - PLAT=i686
   - name: "Linux x86 Python 3.8"
@@ -115,7 +115,7 @@ matrix:
     sudo: required
     env:
       - MB_PYTHON_VERSION=3.8
-      - MB_ML_VER=2014
+      - MB_ML_VER=2010
       - ONNX_ML=1
       - PLAT=i686
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,28 +63,28 @@ matrix:
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.5
-      - MB_ML_VER=2014
+      - MB_ML_VER=2010
       - ONNX_ML=1
   - name: "Linux x64 Python 3.6"
     os: linux 
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.6
-      - MB_ML_VER=2014
+      - MB_ML_VER=2010
       - ONNX_ML=1
   - name: "Linux x64 Python 3.7"
     os: linux 
     sudo: required 
     env: 
       - MB_PYTHON_VERSION=3.7
-      - MB_ML_VER=2014
+      - MB_ML_VER=2010
       - ONNX_ML=1
   - name: "Linux x64 Python 3.8"
     os: linux
     sudo: required
     env:
       - MB_PYTHON_VERSION=3.8
-      - MB_ML_VER=2014
+      - MB_ML_VER=2010
       - ONNX_ML=1
   - name: "Linux x86 Python 3.5"
     os: linux 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
     - REPO_DIR=onnx
-    - BUILD_COMMIT=63a586914d51fdfd6d8668e81de043e3d9b0b382
+    - BUILD_COMMIT=87eb5988a5cced69b946f3d3f2963a0e271940b9
     - PLAT=x86_64
     - PB_VERSION=2.6.1
     - UNICODE_WIDTH=32
@@ -57,45 +57,53 @@ matrix:
   - os: linux 
     sudo: required 
     env: 
-      - MB_PYTHON_VERSION=3.5 
-      - ONNX_ML=1 
+      - MB_PYTHON_VERSION=3.5
+      - MB_ML_VER=2014
+      - ONNX_ML=1
   - os: linux 
     sudo: required 
     env: 
-      - MB_PYTHON_VERSION=3.6 
-      - ONNX_ML=1 
+      - MB_PYTHON_VERSION=3.6
+      - MB_ML_VER=2014
+      - ONNX_ML=1
   - os: linux 
     sudo: required 
     env: 
-      - MB_PYTHON_VERSION=3.7 
+      - MB_PYTHON_VERSION=3.7
+      - MB_ML_VER=2014
       - ONNX_ML=1
   - os: linux
     sudo: required
     env:
       - MB_PYTHON_VERSION=3.8
+      - MB_ML_VER=2014
       - ONNX_ML=1
   - os: linux 
     sudo: required 
     env: 
-      - MB_PYTHON_VERSION=3.5 
-      - ONNX_ML=1 
-      - PLAT=i686 
-  - os: linux 
-    sudo: required 
-    env: 
-      - MB_PYTHON_VERSION=3.6 
-      - ONNX_ML=1 
+      - MB_PYTHON_VERSION=3.5
+      - MB_ML_VER=2014
+      - ONNX_ML=1
       - PLAT=i686
   - os: linux 
     sudo: required 
     env: 
-      - MB_PYTHON_VERSION=3.7 
-      - ONNX_ML=1 
+      - MB_PYTHON_VERSION=3.6
+      - MB_ML_VER=2014
+      - ONNX_ML=1
+      - PLAT=i686
+  - os: linux 
+    sudo: required 
+    env: 
+      - MB_PYTHON_VERSION=3.7
+      - MB_ML_VER=2014
+      - ONNX_ML=1
       - PLAT=i686
   - os: linux
     sudo: required
     env:
       - MB_PYTHON_VERSION=3.8
+      - MB_ML_VER=2014
       - ONNX_ML=1
       - PLAT=i686
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ environment:
 
 install:
 - cmd: set repo_dir=onnx
-- cmd: set build_commit=63a586914d51fdfd6d8668e81de043e3d9b0b382
+- cmd: set build_commit=87eb5988a5cced69b946f3d3f2963a0e271940b9
 - cmd: git submodule update --init --recursive
 - cmd: cd %repo_dir%
 - cmd: git fetch origin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ environment:
 
 install:
 - cmd: set repo_dir=onnx
-- cmd: set build_commit=0c070abb0c40fec649f81a73a75b0098662ec486
+- cmd: set build_commit=63a586914d51fdfd6d8668e81de043e3d9b0b382
 - cmd: git submodule update --init --recursive
 - cmd: cd %repo_dir%
 - cmd: git fetch origin

--- a/config.sh
+++ b/config.sh
@@ -2,7 +2,7 @@
 function build_wheel {
     build_libs
     export ONNX_ML=1
-    time ONNX_NAMESPACE=ONNX_REL_1_7 build_bdist_wheel $@
+    time ONNX_NAMESPACE=ONNX_REL_1_8 build_bdist_wheel $@
 }
 
 function build_libs {


### PR DESCRIPTION
**Description**
-Update commit ID for ONNX 1.8.0 rel-1.8.0 branch
- Remove Python 2.7
- Add MB_ML_VER for Linux Machines to support manylinux
- i686 platforms did not work with MB_ML_VER=2014 so I used MB_ML_VER=2010 for all Linux machines due to consistency.

**Motivation**
TestPypi for ONNX 1.8.0 Release